### PR TITLE
refactor: polishing (#3)

### DIFF
--- a/Example/Example/ContentView.swift
+++ b/Example/Example/ContentView.swift
@@ -90,7 +90,7 @@ struct ContentView: View {
         let response =
             await SNK
             .request(url: URL(string: "https://httpbin.org/post")!)
-            .jsonContentType()
+            .contentType(.json)
             .body(testData)
             .post(validateBodyAs: HttpBinResponse.self)
 
@@ -120,7 +120,7 @@ struct ContentView: View {
         let response =
             await SNK
             .request(url: URL(string: "https://httpbin.org/post")!)
-            .formContentType()
+            .contentType(.json)
             .body(formData)
             .post(validateBodyAs: HttpBinResponse.self)
 
@@ -219,7 +219,7 @@ struct ContentView: View {
         let response =
             await SNK
             .request(url: URL(string: "https://httpbin.org/post")!)
-            .xmlContentType()
+            .contentType(.json)
             .post(validateBodyAs: HttpBinResponse.self)
 
         let result = TestResult(

--- a/Sources/SwiftNetworkKit/Core/ContentType.swift
+++ b/Sources/SwiftNetworkKit/Core/ContentType.swift
@@ -1,0 +1,22 @@
+//
+//  ContentType.swift
+//  SwiftNetworkKit
+//
+//  Created by Stephen T. Sagarino Jr. on 10/7/25.
+//
+
+import Foundation
+
+public enum ContentType: String {
+    case json = "application/json"
+    case formURLEncoded = "application/x-www-form-urlencoded"
+    case multipartFormData = "multipart/form-data"
+    case textPlain = "text/plain"
+    case textHTML = "text/html"
+    case applicationXML = "application/xml"
+    case textXML = "text/xml"
+    case applicationPDF = "application/pdf"
+    case imagePNG = "image/png"
+    case imageJPEG = "image/jpeg"
+    case applicationOctetStream = "application/octet-stream"
+}

--- a/Sources/SwiftNetworkKit/Extensions/SNKDataRequestExtension.swift
+++ b/Sources/SwiftNetworkKit/Extensions/SNKDataRequestExtension.swift
@@ -6,6 +6,11 @@
 //
 
 extension SNKDataRequest {
+    @available(
+        *,
+        deprecated,
+        message: "Use SwiftNetworkKit.ContentType instead"
+    )
     internal struct ContentType {
         public static let json = "application/json"
         public static let formURLEncoded = "application/x-www-form-urlencoded"
@@ -20,16 +25,31 @@ extension SNKDataRequest {
         public static let applicationOctetStream = "application/octet-stream"
     }
 
+    @available(
+        *,
+        deprecated,
+        message: "Use .contentType(.json) instead"
+    )
     /// Sets the Content-Type header to application/json
     public func jsonContentType() -> SNKDataRequest {
         return self.addHeader("Content-Type", value: ContentType.json)
     }
 
+    @available(
+        *,
+        deprecated,
+        message: "Use .contentType(.formURLEncoded) instead"
+    )
     /// Sets the Content-Type header to application/x-www-form-urlencoded
     public func formContentType() -> SNKDataRequest {
         return self.addHeader("Content-Type", value: ContentType.formURLEncoded)
     }
 
+    @available(
+        *,
+        deprecated,
+        message: "Use .contentType(.multipartFormData) instead"
+    )
     /// Sets the Content-Type header to multipart/form-data
     public func multipartContentType() -> SNKDataRequest {
         return self.addHeader(
@@ -38,36 +58,71 @@ extension SNKDataRequest {
         )
     }
 
+    @available(
+        *,
+        deprecated,
+        message: "Use .contentType(.textPlain) instead"
+    )
     /// Sets the Content-Type header to text/plain
     public func textContentType() -> SNKDataRequest {
         return self.addHeader("Content-Type", value: ContentType.textPlain)
     }
 
+    @available(
+        *,
+        deprecated,
+        message: "Use .contentType(.textHTML) instead"
+    )
     /// Sets the Content-Type header to text/html
     public func htmlContentType() -> SNKDataRequest {
         return self.addHeader("Content-Type", value: ContentType.textHTML)
     }
 
+    @available(
+        *,
+        deprecated,
+        message: "Use .contentType(.applicationXML) instead"
+    )
     /// Sets the Content-Type header to application/xml
     public func xmlContentType() -> SNKDataRequest {
         return self.addHeader("Content-Type", value: ContentType.applicationXML)
     }
 
+    @available(
+        *,
+        deprecated,
+        message: "Use .contentType(.applicationPDF) instead"
+    )
     /// Sets the Content-Type header to application/pdf
     public func pdfContentType() -> SNKDataRequest {
         return self.addHeader("Content-Type", value: ContentType.applicationPDF)
     }
 
+    @available(
+        *,
+        deprecated,
+        message: "Use .contentType(.imagePNG) instead"
+    )
     /// Sets the Content-Type header to image/png
     public func pngContentType() -> SNKDataRequest {
         return self.addHeader("Content-Type", value: ContentType.imagePNG)
     }
 
+    @available(
+        *,
+        deprecated,
+        message: "Use .contentType(.imageJPEG) instead"
+    )
     /// Sets the Content-Type header to image/jpeg
     public func jpegContentType() -> SNKDataRequest {
         return self.addHeader("Content-Type", value: ContentType.imageJPEG)
     }
 
+    @available(
+        *,
+        deprecated,
+        message: "Use .contentType(.applicationOctetStream) instead"
+    )
     /// Sets the Content-Type header to application/octet-stream
     public func binaryContentType() -> SNKDataRequest {
         return self.addHeader(


### PR DESCRIPTION
* chore: create root `ContentType` enum

* chore: add `contentType` variable for SNKDataRequest

created setter and variable type for it

* refactor: deprecates all the `SNKDataRequest.ContentType`

* refactor(example): edit `.jsonContentType()` to `.contentType(.json)`

* feat(image-upload): can now set `Data` as body of http request

* feat(cache): add `cachePolicy` setter for SNKDataRequest